### PR TITLE
PSE configuration for our circuits

### DIFF
--- a/pse/README.md
+++ b/pse/README.md
@@ -13,3 +13,8 @@ This configuration is used to apply our route to https://ceremony.pse.dev and pr
 **How to contribute**: https://p0tion.super.site/ce8f7047468b41239dc512919644535c
 
 **How P0tion work**: https://p0tion.super.site/9110e0b3c8c1404a9598323731974455
+
+### circom compile params
+- cargo 1.88.0 (873a06493 2025-05-10)
+- rustc 1.88.0 (6b00bc388 2025-06-23)
+- circom compiler 2.2.2

--- a/pse/README.md
+++ b/pse/README.md
@@ -10,9 +10,28 @@ This configuration is used to apply our route to https://ceremony.pse.dev and pr
 
 **Sample config**: https://github.com/privacy-scaling-explorations/DefinitelySetup/blob/main/ceremonies/rln-trusted-setup-ceremony/p0tionConfig.json
 
-**How to contribute**: https://p0tion.super.site/ce8f7047468b41239dc512919644535c
-
 **How P0tion work**: https://p0tion.super.site/9110e0b3c8c1404a9598323731974455
+
+**How to contribute**: 
+
+The following are the commands to contribute to the test ceremony
+``` bash
+sudo npm install -g @stagtion/stagcli
+stagcli auth
+stagcli contribute -c ethstorage-trusted-setup-ceremony
+stagcli clean
+stagcli logout
+```
+
+The following are the commands to contribute to the product ceremony
+``` bash
+sudo npm install -g @p0tion/phase2cli
+phase2cli auth
+phase2cli contribute -c ethstorage-trusted-setup-ceremony
+phase2cli clean
+phase2cli logout
+``` 
+
 
 ### circom compile params
 - cargo 1.88.0 (873a06493 2025-05-10)

--- a/pse/README.md
+++ b/pse/README.md
@@ -17,4 +17,4 @@ This configuration is used to apply our route to https://ceremony.pse.dev and pr
 ### circom compile params
 - cargo 1.88.0 (873a06493 2025-05-10)
 - rustc 1.88.0 (6b00bc388 2025-06-23)
-- circom compiler 2.2.2
+- circom compiler 2.2.2 (e410b0d5cd2948a15931df0bc50d79ce56fa8c32)

--- a/pse/README.md
+++ b/pse/README.md
@@ -1,0 +1,15 @@
+<p align="center">
+    <h1 align="center">
+        PSE configuration for our circuits
+    </h1>
+</p>
+
+This configuration is used to apply our route to https://ceremony.pse.dev and provide it to all users participating in the trusted setup ceremony.
+
+**Config fields description**: https://github.com/privacy-scaling-explorations/DefinitelySetup/blob/main/ceremonies/README.md#template-in-details
+
+**Sample config**: https://github.com/privacy-scaling-explorations/DefinitelySetup/blob/main/ceremonies/rln-trusted-setup-ceremony/p0tionConfig.json
+
+**How to contribute**: https://p0tion.super.site/ce8f7047468b41239dc512919644535c
+
+**How P0tion work**: https://p0tion.super.site/9110e0b3c8c1404a9598323731974455

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -14,7 +14,7 @@
           },
           "template": {
               "source": "https://github.com/ethstorage/zk-decoder/blob/main/circom/circuits/blob_poseidon.circom",
-              "commitHash": "40b96c29deb24276ea164217e46d2d55e54ce583",
+              "commitHash": "52f538629440fc97dc931e04fdf81dc2362491ae",
               "paramsConfiguration": []
           },
           "verification": {
@@ -37,7 +37,7 @@
           },
           "template": {
               "source": "https://github.com/ethstorage/zk-decoder/blob/main/circom/circuits/blob_poseidon_2.circom",
-              "commitHash": "40b96c29deb24276ea164217e46d2d55e54ce583",
+              "commitHash": "52f538629440fc97dc931e04fdf81dc2362491ae",
               "paramsConfiguration": []
           },
           "verification": {

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -1,6 +1,6 @@
 {
-  "title": "Ethstorage Circuits Ceremony",
-  "description": "This is the trusted setup ceremony for Ethstorage Circuits used to prove storage on L2 dynamic datasets with an Ethereum L1 Contract",
+  "title": "Ethstorage Trusted Setup Ceremony",
+  "description": "This is a trusted setup ceremony for the Ethstorage Circuits which is used to prove storage on L2 dynamic datasets with an Ethereum L1 Contract",
   "startDate": "2025-07-18T00:00:00",
   "endDate": "2025-07-23T00:00:00",
   "timeoutMechanismType": "DYNAMIC",
@@ -30,7 +30,7 @@
           "sequencePosition": "1"
       },
 	  {
-          "description": "blob encoder using n Poseidon hash (n = 2), circom compile with --O2 paramter",
+          "description": "combine multiple blob poseidon circuits into one (n = 2), circom compile with --O2 paramter",
           "compiler": {
               "version": "2.2.2",
               "commitHash": "e410b0d5cd2948a15931df0bc50d79ce56fa8c32"

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -1,6 +1,6 @@
 {
   "title": "Ethstorage Trusted Setup Ceremony",
-  "description": "This is a trusted setup ceremony for the Ethstorage Circuits which is used to prove storage on L2 dynamic datasets with an Ethereum L1 Contract",
+  "description": "This trusted setup ceremony is for the Ethstorage circuits, which enable proof of storage for dynamic L2 datasets through a verifier contract on Ethereum L1.",
   "startDate": "2025-07-18T00:00:00",
   "endDate": "2025-07-23T00:00:00",
   "timeoutMechanismType": "DYNAMIC",

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -1,6 +1,6 @@
 {
-  "title": "Ethstorage Trusted Setup Ceremony",
-  "description": "This trusted setup ceremony is for the Ethstorage circuits, which enable proof of storage for dynamic L2 datasets through a verifier contract on Ethereum L1.",
+  "title": "EthStorage Trusted Setup Ceremony",
+  "description": "This trusted setup ceremony is for the EthStorage circuits, which enable proof of storage for dynamic L2 datasets through a verifier contract on Ethereum L1.",
   "startDate": "2025-07-18T00:00:00",
   "endDate": "2025-07-23T00:00:00",
   "timeoutMechanismType": "DYNAMIC",

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -7,7 +7,7 @@
   "penalty": "20",
   "circuits": [
       {
-          "description": "blob encoder using Poseidon hash, circom compile with --O2 paramter",
+          "description": "Compile with --O2 paramter",
           "compiler": {
               "version": "2.2.2",
               "commitHash": "e410b0d5cd2948a15931df0bc50d79ce56fa8c32"
@@ -30,7 +30,7 @@
           "sequencePosition": "1"
       },
 	  {
-          "description": "combine multiple blob poseidon circuits into one (n = 2), circom compile with --O2 paramter",
+          "description": "Compile with --O2 paramter",
           "compiler": {
               "version": "2.2.2",
               "commitHash": "e410b0d5cd2948a15931df0bc50d79ce56fa8c32"

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -2,7 +2,7 @@
   "title": "Ethstorage Circuits Ceremony",
   "description": "This is a trusted setup ceremony for the Ethstorage Circuits with is used to proof storage on L2 dynamic datasets with an Ethereum L1 Contract",
   "startDate": "2025-07-18T00:00:00",
-  "endDate": "2025-08-01T00:00:00",
+  "endDate": "2025-07-23T00:00:00",
   "timeoutMechanismType": "DYNAMIC",
   "penalty": "20",
   "circuits": [

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -7,10 +7,10 @@
   "penalty": "20",
   "circuits": [
       {
-          "description": "A simple blob encoder using Poseidon hash",
+          "description": "blob encoder using Poseidon hash, circom compile with --O2 paramter",
           "compiler": {
-              "version": "2.0.6",
-              "commitHash": "3fa5592c41a59a8a79cb6a328606c64a4b451762"
+              "version": "2.2.2",
+              "commitHash": "e410b0d5cd2948a15931df0bc50d79ce56fa8c32"
           },
           "template": {
               "source": "https://github.com/ethstorage/zk-decoder/blob/main/circom/circuits/blob_poseidon.circom",
@@ -21,8 +21,8 @@
               "cfOrVm": "CF"
           },
           "artifacts": {
-              "r1csStoragePath": "https://drive.google.com/file/d/1rpXBqScljsBXP70dvYku5Vtsjm1a8HE1",
-              "wasmStoragePath": "https://drive.google.com/file/d/1hDDXINT-5-6UUHxLroR-hXeqFeRZUJ0U"
+              "r1csStoragePath": "https://ethstorage-trusted-setup.s3.us-west-2.amazonaws.com/blob_poseidon.r1cs",
+              "wasmStoragePath": "https://ethstorage-trusted-setup.s3.us-west-2.amazonaws.com/blob_poseidon.wasm"
           },
           "name": "blob poseidon circuit",
           "dynamicThreshold": "50",
@@ -30,10 +30,10 @@
           "sequencePosition": "1"
       },
 	  {
-          "description": "blob encoder using Poseidon hash, n = 2",
+          "description": "blob encoder using multi (n = 2) Poseidon hash, circom compile with --O2 paramter",
           "compiler": {
-              "version": "2.0.6",
-              "commitHash": "3fa5592c41a59a8a79cb6a328606c64a4b451762"
+              "version": "2.2.2",
+              "commitHash": "e410b0d5cd2948a15931df0bc50d79ce56fa8c32"
           },
           "template": {
               "source": "https://github.com/ethstorage/zk-decoder/blob/main/circom/circuits/blob_poseidon_2.circom",
@@ -44,8 +44,8 @@
               "cfOrVm": "CF"
           },
           "artifacts": {
-              "r1csStoragePath": "https://drive.google.com/file/d/16mDRbs540a2E7W1yOZRufkjs7Yrl_ILD",
-              "wasmStoragePath": "https://drive.google.com/file/d/1bBCKOF0F3wtV--2S57kRySEFZ0mzhxS7"
+              "r1csStoragePath": "https://ethstorage-trusted-setup.s3.us-west-2.amazonaws.com/blob_poseidon_2.r1cs",
+              "wasmStoragePath": "https://ethstorage-trusted-setup.s3.us-west-2.amazonaws.com/blob_poseidon_2.wasm"
           },
           "name": "blob poseidon 2 circuit",
           "dynamicThreshold": "50",

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -1,6 +1,6 @@
 {
   "title": "Ethstorage Circuits Ceremony",
-  "description": "This is a trusted setup ceremony for the Ethstorage Circuits with is used to proof storage on L2 dynamic datasets with an Ethereum L1 Contract",
+  "description": "This is the trusted setup ceremony for Ethstorage Circuits used to prove storage on L2 dynamic datasets with an Ethereum L1 Contract",
   "startDate": "2025-07-18T00:00:00",
   "endDate": "2025-07-23T00:00:00",
   "timeoutMechanismType": "DYNAMIC",
@@ -30,7 +30,7 @@
           "sequencePosition": "1"
       },
 	  {
-          "description": "blob encoder using multi (n = 2) Poseidon hash, circom compile with --O2 paramter",
+          "description": "blob encoder using n Poseidon hash (n = 2), circom compile with --O2 paramter",
           "compiler": {
               "version": "2.2.2",
               "commitHash": "e410b0d5cd2948a15931df0bc50d79ce56fa8c32"

--- a/pse/p0tionConfig.json
+++ b/pse/p0tionConfig.json
@@ -1,0 +1,56 @@
+{
+  "title": "Ethstorage Circuits Ceremony",
+  "description": "This is a trusted setup ceremony for the Ethstorage Circuits with is used to proof storage on L2 dynamic datasets with an Ethereum L1 Contract",
+  "startDate": "2025-07-18T00:00:00",
+  "endDate": "2025-08-01T00:00:00",
+  "timeoutMechanismType": "DYNAMIC",
+  "penalty": "20",
+  "circuits": [
+      {
+          "description": "A simple blob encoder using Poseidon hash",
+          "compiler": {
+              "version": "2.0.6",
+              "commitHash": "3fa5592c41a59a8a79cb6a328606c64a4b451762"
+          },
+          "template": {
+              "source": "https://github.com/ethstorage/zk-decoder/blob/main/circom/circuits/blob_poseidon.circom",
+              "commitHash": "40b96c29deb24276ea164217e46d2d55e54ce583",
+              "paramsConfiguration": []
+          },
+          "verification": {
+              "cfOrVm": "CF"
+          },
+          "artifacts": {
+              "r1csStoragePath": "https://drive.google.com/file/d/1rpXBqScljsBXP70dvYku5Vtsjm1a8HE1",
+              "wasmStoragePath": "https://drive.google.com/file/d/1hDDXINT-5-6UUHxLroR-hXeqFeRZUJ0U"
+          },
+          "name": "blob poseidon circuit",
+          "dynamicThreshold": "50",
+          "fixedTimeWindow": "15",
+          "sequencePosition": "1"
+      },
+	  {
+          "description": "blob encoder using Poseidon hash, n = 2",
+          "compiler": {
+              "version": "2.0.6",
+              "commitHash": "3fa5592c41a59a8a79cb6a328606c64a4b451762"
+          },
+          "template": {
+              "source": "https://github.com/ethstorage/zk-decoder/blob/main/circom/circuits/blob_poseidon_2.circom",
+              "commitHash": "40b96c29deb24276ea164217e46d2d55e54ce583",
+              "paramsConfiguration": []
+          },
+          "verification": {
+              "cfOrVm": "CF"
+          },
+          "artifacts": {
+              "r1csStoragePath": "https://drive.google.com/file/d/16mDRbs540a2E7W1yOZRufkjs7Yrl_ILD",
+              "wasmStoragePath": "https://drive.google.com/file/d/1bBCKOF0F3wtV--2S57kRySEFZ0mzhxS7"
+          },
+          "name": "blob poseidon 2 circuit",
+          "dynamicThreshold": "50",
+          "fixedTimeWindow": "30",
+          "sequencePosition": "2"
+      }
+  ]
+}


### PR DESCRIPTION
This configuration is used to apply our route to https://ceremony.pse.dev and provide it to all users participating in the trusted setup ceremony.

**Config fields description**: https://github.com/privacy-scaling-explorations/DefinitelySetup/blob/main/ceremonies/README.md#template-in-details

**Sample config**: https://github.com/privacy-scaling-explorations/DefinitelySetup/blob/main/ceremonies/rln-trusted-setup-ceremony/p0tionConfig.json