### PR TITLE
Add --O2 paramter to the build paramter 

### DIFF
--- a/circom/package.json
+++ b/circom/package.json
@@ -15,6 +15,6 @@
     "elliptic": "^6.5.4",
     "eslint": "^8.23.1",
     "prettier": "^2.7.1",
-    "snarkjs": "^0.5.0"
+    "snarkjs": "^0.7.0"
   }
 }

--- a/circom/scripts/build/build.sh
+++ b/circom/scripts/build/build.sh
@@ -14,7 +14,7 @@ fi
 echo "****COMPILING CIRCUIT****"
 start=`date +%s`
 set -x
-circom $CIRCUITS_DIR/$CIRCUIT_NAME.circom -p ${CURVE} --r1cs --wasm --sym --c --wat --output "$BUILD_DIR" || exit
+circom $CIRCUITS_DIR/$CIRCUIT_NAME.circom -p ${CURVE} --O2 --r1cs --wasm --sym --c --wat --output "$BUILD_DIR" || exit
 { set +x; } 2>/dev/null
 end=`date +%s`
 echo "DONE ($((end-start))s)"


### PR DESCRIPTION
`--O2` was added to circom at [v2.0.9](https://github.com/iden3/circom/releases/tag/v2.0.9) to sepcify the simplification type when build circuits, and its default value is changed at [v2.2.0](https://github.com/iden3/circom/releases/tag/v2.2.0). 

To ensure that we use a fixed simplification type when building, add the parameter `--O2` to our build parameters. 

Note: 
`--O2` paramter: This level applies intermediate optimizations to reduce constraint count without altering circuit logic. Learn more about Circom optimizations [here](https://github.com/iden3/circom/blob/master/mkdocs/docs/circom-language/circom-insight/simplification.md).

snarkjs v0.5.0 uses deplicated node.js 14/16, and its `snarkjs zkey verify` results will differ from snarkjs v0.7.0 or later.
